### PR TITLE
fix server for windows with path.join

### DIFF
--- a/workshopper.js
+++ b/workshopper.js
@@ -274,7 +274,7 @@ Workshopper.prototype._printHelp = function () {
 
 Workshopper.prototype._runServer = function (lang) {
   var server = http.createServer(
-    ecstatic({ root: this.appDir + '/guide' })
+    ecstatic({ root: path.join(this.appDir, 'guide') })
   ).listen(0)
 
   server.on('listening', function () {


### PR DESCRIPTION
I am not sure which branch to PR to, but I guess it's `verify`?  There was someone with windows having an issue with `git-it server` (https://github.com/nodeschool/discussions/issues/549). I think I fixed it with using `path.join` instead of string concats.
