### PR TITLE
editable string output for lesson select/pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
+.idea
+*.iml
+npm-debug.log
+dump.rdb
 node_modules
+results.tap
+results.xml
+npm-shrinkwrap.json
+.DS_Store
+*/.DS_Store
+*/*/.DS_Store
+._*
+*/._*
+*/*/._*

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create a new Node project, add a `"bin"` that looks something like this:
 
 const Workshopper = require('workshopper')
     , path        = require('path')
+    , strings     = require('./strings')
 
 Workshopper({
     name              : 'learnyounode'
@@ -29,6 +30,7 @@ Workshopper({
   , helpFile          : path.join(__dirname, 'help.txt')
   , prerequisitesFile : path.join(__dirname, 'prerequisites.txt')
   , creditsFile       : path.join(__dirname, 'credits.txt')
+  , strings           : strings
 }).init()
 ```
 
@@ -39,6 +41,8 @@ The `'helpFile'` option is optional but if you supply one, users will get the co
 The `'prerequisitesFile'` option is optional but if you supply one, users will get the contents of this file when they type `app prerequisites` (where 'app' is your workshop application name). This file is intended to contain any instructions required for installations or set ups which are prerequisites needed to begin the lessons. They will also see a pointer to this whenever they select a new exercise.
 
 The `'creditsFile'` option is optional but if you supply one, users will get the contents of this file when they type `app credits` (where 'app' is your workshop application name). This file is intended to give credit to those who have added or assisted in creating the exercises. They will also see a pointer to this whenever they select a new exercise.
+
+`'strings'` points to an optional .json file that allows you to customize what a user sees after selection of a workshopper lesson. This allows a workshop creator to use the much simpler workshopper-jlord framework w
 
 Create a *menu.json* file in your project that looks something like this:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,20 @@ The `'prerequisitesFile'` option is optional but if you supply one, users will g
 
 The `'creditsFile'` option is optional but if you supply one, users will get the contents of this file when they type `app credits` (where 'app' is your workshop application name). This file is intended to give credit to those who have added or assisted in creating the exercises. They will also see a pointer to this whenever they select a new exercise.
 
-`'strings'` points to an optional .json file that allows you to customize what a user sees after selection of a workshopper lesson. It takes four key:value pairs: `'guide'`, `'verify'`, `'offline'`, and `'next'`. If this file is absent, selecting any lesson will return some stdout that points users to the git-it help guides. 
+`'strings'` points to an optional .json file that allows you to customize what a user sees after selection of a workshopper lesson. If this file is absent, selecting any lesson will also return some stdout that points users to the git-it help guides. 
+
+A *strings.json* file looks something like this.
+
+```js
+{
+  "guide": "To view the guide",
+  "offline": "To view the guide offline, go here:",
+  "verify": "Type 'workshop-name verify' to check your submission.",
+  "next": "Type 'workshop-name' to open the menu and move onto the next lesson."
+}
+```
+
+
 Create a *menu.json* file in your project that looks something like this:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ The `'prerequisitesFile'` option is optional but if you supply one, users will g
 
 The `'creditsFile'` option is optional but if you supply one, users will get the contents of this file when they type `app credits` (where 'app' is your workshop application name). This file is intended to give credit to those who have added or assisted in creating the exercises. They will also see a pointer to this whenever they select a new exercise.
 
-`'strings'` points to an optional .json file that allows you to customize what a user sees after selection of a workshopper lesson. This allows a workshop creator to use the much simpler workshopper-jlord framework w
-
+`'strings'` points to an optional .json file that allows you to customize what a user sees after selection of a workshopper lesson. It takes four key:value pairs: `'guide'`, `'verify'`, `'offline'`, and `'next'`. If this file is absent, selecting any lesson will return some stdout that points users to the git-it help guides. 
 Create a *menu.json* file in your project that looks something like this:
 
 ```js

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "guide": "» Open the guide in your browser: jlord.github.io/git-it\n' + '  » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html\n'",
+  "offline": "     '  » To view guide offline, copy this address to your browser:\n' + '  » ' + pathtoguide + '.html \n' + '  » ' + pathtoguide + '-zhtw.html\n'",
+  "verify": "» To verify your work for this problem, run: `' + this.name + ' verify`.\n",
+  "next": "» Run `' + this.name + '` again to launch menu & go onto next challenge.\n'"
+}

--- a/config.json
+++ b/config.json
@@ -1,6 +1,0 @@
-{
-  "guide": "» Open the guide in your browser: jlord.github.io/git-it\n' + '  » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html\n'",
-  "offline": "     '  » To view guide offline, copy this address to your browser:\n' + '  » ' + pathtoguide + '.html \n' + '  » ' + pathtoguide + '-zhtw.html\n'",
-  "verify": "» To verify your work for this problem, run: `' + this.name + ' verify`.\n",
-  "next": "» Run `' + this.name + '` again to launch menu & go onto next challenge.\n'"
-}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "workshopper",
-  "version": "0.7.0",
+  "name": "workshopper-jlord",
+  "version": "0.0.0",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",
+  "contributors": ["jlord"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/rvagg/workshopper.git"
+    "url": "https://github.com/jlord/workshopper.git#verify"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,25 +1,28 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",
-  "contributors": ["jlord"],
+  "contributors": [
+    "jlord"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/jlord/workshopper.git#verify"
   },
   "license": "MIT",
   "dependencies": {
-    "map-async": "~0.1.1",
-    "tuple-stream": "~0.0.2",
-    "split": "~0.2.10",
-    "through": "~2.3.4",
-    "mkdirp": "~0.3.5",
     "colors-tmpl": "~0.1.0",
-    "terminal-menu": "~0.2.0",
+    "ecstatic": "^0.5.4",
+    "map-async": "~0.1.1",
+    "mkdirp": "~0.3.5",
+    "msee": "~0.1.1",
     "optimist": "~0.6.0",
-    "xtend": "~2.1.2",
-    "msee": "~0.1.1"
+    "split": "~0.2.10",
+    "terminal-menu": "~0.2.0",
+    "through": "~2.3.4",
+    "tuple-stream": "~0.0.2",
+    "xtend": "~2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "terminal-menu": "~0.2.0",
     "through": "~2.3.4",
     "tuple-stream": "~0.0.2",
-    "xtend": "~2.1.2"
+    "xtend": "~2.1.2",
+    "shelljs": "~0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,11 +26,5 @@
     "through": "~2.3.4",
     "tuple-stream": "~0.0.2",
     "xtend": "~2.1.2"
-  },
-  "workshopStrings": {
-    "guide": "» Open the guide in your browser: jlord.github.io/git-it\n' + '  » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html\n'",
-    "offline": "     '  » To view guide offline, copy this address to your browser:\n' + '  » ' + pathtoguide + '.html \n' + '  » ' + pathtoguide + '-zhtw.html\n'",
-    "verify": "» To verify your work for this problem, run: `' + this.name + ' verify`.\n",
-    "next": "» Run `' + this.name + '` again to launch menu & go onto next challenge.\n'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",
   "contributors": [
-    "jlord"
+    "jlord",
+    "theffner"
   ],
   "repository": {
     "type": "git",
@@ -24,5 +25,11 @@
     "through": "~2.3.4",
     "tuple-stream": "~0.0.2",
     "xtend": "~2.1.2"
+  },
+  "workshopStrings": {
+    "guide": "» Open the guide in your browser: jlord.github.io/git-it\n' + '  » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html\n'",
+    "offline": "     '  » To view guide offline, copy this address to your browser:\n' + '  » ' + pathtoguide + '.html \n' + '  » ' + pathtoguide + '-zhtw.html\n'",
+    "verify": "» To verify your work for this problem, run: `' + this.name + ' verify`.\n",
+    "next": "» Run `' + this.name + '` again to launch menu & go onto next challenge.\n'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper-jlord",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "colors-tmpl": "~0.1.0",
     "ecstatic": "^0.5.4",
+    "lodash": "^3.10.1",
     "map-async": "~0.1.1",
     "mkdirp": "~0.3.5",
     "msee": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workshopper",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A terminal workshop runner framework",
   "main": "./workshopper.js",
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "colors-tmpl": "~0.1.0",
     "terminal-menu": "~0.2.0",
     "optimist": "~0.6.0",
-    "xtend": "~2.1.1",
-    "msee": "~0.1.0-alpha.3"
+    "xtend": "~2.1.2",
+    "msee": "~0.1.1"
   }
 }

--- a/print-text.js
+++ b/print-text.js
@@ -1,7 +1,11 @@
-const fs         = require('fs')
-    , path       = require('path')
-    , colorsTmpl = require('colors-tmpl')
-    , msee       = require('msee')
+const fs          = require('fs')
+    , path        = require('path')
+    , colorsTmpl  = require('colors-tmpl')
+    , msee        = require('msee')
+    , mseeOptions = {
+          paragraphStart: ''
+        , paragraphEnd: '\n\n'
+      }
 
 function printText (name, appDir, file, filetype, callback) {
   var variables = {
@@ -24,7 +28,7 @@ function printText (name, appDir, file, filetype, callback) {
     })
     if (filetype == '.md') {
       // convert Markdown to ANSI
-      contents = msee.parse(contents)
+      contents = msee.parse(contents, mseeOptions)
     }
     console.log(contents)
     callback && callback()

--- a/strings.json
+++ b/strings.json
@@ -1,0 +1,6 @@
+{
+  "guide": "» Open the guide in your browser: jlord.github.io/git-it\n » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html",
+  "offline": "» To view guide offline, copy this address to your browser:\n » pathtoguide + .html \n » pathtoguide + -zhtw.html\n",
+  "verify": "» To verify your work for this problem, run: `git -it verify`.\n",
+  "next": "» Run `git-it` again to launch menu & go onto next challenge.\n'"
+}

--- a/usage.txt
+++ b/usage.txt
@@ -11,4 +11,6 @@
   {bold}{green}{appname}{/green} print{/bold}
     Print the instructions for the currently selected workshop.
   {bold}{green}{appname}{/green} run{/bold}
-    Run the challenge's verify without triggering verify .
+    Run the challenge's verify without triggering verify.
+  {bold}{green}{appname}{/green} reset{/bold}
+    Clear all challenges completed status.

--- a/usage.txt
+++ b/usage.txt
@@ -10,7 +10,5 @@
     Show the currently selected workshop.
   {bold}{green}{appname}{/green} print{/bold}
     Print the instructions for the currently selected workshop.
-  {bold}{green}{appname}{/green} run program.js{/bold}
-    Run your program against the selected input.
-  {bold}{green}{appname}{/green} verify program.js{/bold}
-    Verify your program against the expected output.
+  {bold}{green}{appname}{/green} run{/bold}
+    Run the challenge's verify without triggering verify .

--- a/workshopper.js
+++ b/workshopper.js
@@ -380,7 +380,6 @@ function onselect (name) {
     file = txt
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
-    console.log(repeat('-', this.width) + '\n')
     console.log(
       bold('\n » To print these instructions again, run: `' + this.name + ' print`.\n'))
     // console.log(

--- a/workshopper.js
+++ b/workshopper.js
@@ -277,9 +277,11 @@ Workshopper.prototype._runServer = function () {
 
   server.on('listening', function () {
     var addr = this.address()
-    console.log('Open this in your browser: %s:%s', 'http://localhost', addr.port + '\n'
-      + 'Open a new terminal window and run `git-it` again.\n'
-      + 'When you are done with server, press CTRL + C to end it.')
+    console.log(bold('\n Server time! ᕕ( ᐛ )ᕗ') + '\n The server is now running from this window.\n\n'
+      + ' It\'s serving the guide at this address, paste it in your broswer: %s:%s', bold('http://localhost'), bold(addr.port) + '\n'
+      + ' Next, open a new terminal window and run `git-it` again and work from there.\n\n'
+      + ' When you are done you can close this window or press CTRL + C to end the server.\n'
+      + ' BEEP BOOP')
   })
 }
 

--- a/workshopper.js
+++ b/workshopper.js
@@ -380,6 +380,7 @@ function onselect (name) {
     file = txt
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
+    console.log(repeat('-', this.width) + '\n')
     console.log(
       bold('\n » To print these instructions again, run: `' + this.name + ' print`.\n'))
     // console.log(

--- a/workshopper.js
+++ b/workshopper.js
@@ -18,12 +18,12 @@ const showMenu  = require('./menu')
     , yellow    = require('./term-util').yellow
     , center    = require('./term-util').center
 
-var config = require('./config');
+var strings = require('./strings');
 
 const defaultWidth = 65;
 
 function Workshopper (options) {
-  config = _.assign(config, options.config)
+  strings = _.assign(strings, options.strings)
 
   if (!(this instanceof Workshopper))
     return new Workshopper(options)
@@ -410,11 +410,11 @@ function onselect (name) {
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
     var pathtoguide = path.join(this.appDir, 'guide', 'index');
-//    console.log(bold(green(config.verify)))
-//    console.log(bold(green(config.next)))
+    console.log(bold(green(strings.verify)))
+    console.log(bold(green(strings.next)))
 //
-//    console.log(bold(green(config.guide)))
-//    console.log(config.offline)
+    console.log(bold(green(strings.guide)))
+    console.log(bold(green(strings.offline)))
 //
 //    console.log()
   }.bind(this))

--- a/workshopper.js
+++ b/workshopper.js
@@ -7,6 +7,8 @@ const argv       = require('optimist').argv
     , http       = require('http')
     , ecstatic   = require('ecstatic')
     , _          = require('lodash')
+    , shell      = require('shelljs')
+
 
 const showMenu  = require('./menu')
     , verify    = require('./verify')
@@ -312,8 +314,6 @@ function onpass (setup, dir, current) {
   if (setup.hideSolutions)
     return
 
-  // console.log('\nHere\'s what the official solution is if you want to compare notes:\n')
-
   var solutions = fs.readdirSync(dir).filter(function (file) {
         return (/^solution.*\.js/).test(file)
       }).map(function (file) {
@@ -359,6 +359,19 @@ function onpass (setup, dir, current) {
         if (remaining === 0) {
           console.log('You\'ve finished all the challenges! Hooray!\n')
         } else {
+          // trying to show our example
+          console.log(repeat('-', this.width))
+          console.log('Here\'s what our solution looks like:' + '\n')
+
+          var example = fs.readdirSync(dir).filter(function (file) {
+            return (/^example.*\.html/).test(file)
+          }).map(function (file) {
+              shell.echo(fs.readFileSync(path.join(dir, file), 'utf8'))
+              //    .toString()
+              //     .replace(/^/gm, '  ')
+            }
+          )
+
           console.log(repeat('-', this.width) + '\n')
           console.log(
               'You have '
@@ -388,22 +401,17 @@ function onfail (setup, dir, current) {
     console.log(repeat('-', this.width) + '\n')
 
   // trying to show our example
+  console.log('Here\'s what our solution looks like:')
 
-    var example = fs.readdirSync(dir).filter(function (file) {
+  var example = fs.readdirSync(dir).filter(function (file) {
       return (/^example.*\.html/).test(file)
-    })
-
-//      .map(function (file) {
-//      return fs.readFileSync(path.join(dir, file), 'utf8')
-//         // .toString()
-//        //  .replace(/^/gm, '  ')
-//      }
-//    )
-
-    console.log('Here\'s what our solution looks like:')
-    console.log(example)
-    console.log(repeat('-', this.width) + '\n')
-
+    }).map(function (file) {
+        shell.echo(fs.readFileSync(path.join(dir, file), 'utf8'))
+     //    .toString()
+    //     .replace(/^/gm, '  ')
+      }
+    )
+  console.log(repeat('-', this.width) + '\n')
 }
 
 function onselect (name) {
@@ -433,5 +441,6 @@ function onselect (name) {
     console.log(bold(green(strings.offline)))
   }.bind(this))
 }
+
 
 module.exports = Workshopper

--- a/workshopper.js
+++ b/workshopper.js
@@ -58,8 +58,12 @@ Workshopper.prototype.init = function () {
   if (argv.h || argv.help || argv._[0] == 'help')
     return this._printHelp()
 
-if (argv.s || argv.sever || argv._[0] == 'server')
+if (argv.s || argv.server || argv._[0] == 'server')
+  if (argv._[1]) {
+    return this._runServer(argv._[1])
+  } else {
     return this._runServer()
+  }
 
   if (argv._[0] == 'credits')
     return this._printCredits()
@@ -268,16 +272,15 @@ Workshopper.prototype._printHelp = function () {
     printText(this.name, this.appDir, this.helpFile)
 }
 
-Workshopper.prototype._runServer = function () {
-  var dirname = __dirname.split('git-it/')
-  var root = dirname[0] + 'git-it/guide'
+Workshopper.prototype._runServer = function (lang) {
   var server = http.createServer(
-    ecstatic({ root: root })
+    ecstatic({ root: this.appDir + '/guide' })
   ).listen(0)
 
   server.on('listening', function () {
     var addr = this.address()
-    console.log('Open this in your browser: %s:%s', 'http://localhost', addr.port + '\n'
+    var langLocation = addr.port + (lang ? '/index-' + lang + '.html' : '')
+    console.log('Open this in your browser: %s%s', 'http://localhost:' + langLocation , '\n'
       + 'Open a new terminal window and run `git-it` again.\n'
       + 'When you are done with server, press CTRL + C to end it.')
   })

--- a/workshopper.js
+++ b/workshopper.js
@@ -356,6 +356,7 @@ function onfail (setup, dir, current) {
     console.log('\nYour solution to ' + current + ' didn\'t pass. Try again!')
   else
     console.log('\nYour solution to ' + current + ' didn\'t match the expected output.\nTry again!')
+    console.log(repeat('-', this.width) + '\n')
 }
 
 function onselect (name) {

--- a/workshopper.js
+++ b/workshopper.js
@@ -404,7 +404,7 @@ function onselect (name) {
     file = txt
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
-    var pathtoguide = this.appDir + '/guide/index.html'
+    var pathtoguide = path.join(this.appDir,'guide', 'index.html')
     // console.log(
     //   bold('\n » To print these instructions again, run: `' + this.name + ' print`.\n'))
     // console.log(

--- a/workshopper.js
+++ b/workshopper.js
@@ -404,31 +404,35 @@ function onselect (name) {
     file = txt
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
-    var pathtoguide = path.join(this.appDir,'guide', 'index.html')
+    var pathtoguide = path.join(this.appDir,'guide', 'index')
     // console.log(
     //   bold('\n » To print these instructions again, run: `' + this.name + ' print`.\n'))
     // console.log(
     //   bold(' » To execute your program in a test environment, run:\n   `' + this.name + ' run program.js`.'))
     console.log(
-      bold('  » To verify your work for this problem, run: `' + this.name + ' verify`.\n'))
+      bold(green('  » To verify your work for this problem, run: `' + this.name + ' verify`.\n  » Run `git-it` again to launch menu & go onto next challenge\n')))
+    // console.log(
+    //   bold(green('  » Run `git-it` again to launch menu & go onto next challenge\n')))
+    console.log(bold(green('  GUIDE\n')))
+    console.log(green('  » Open the guide in your browser: jlord.github.io/git-it\n' + '  » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html\n'))
+    // console.log(
+    //   bold('  » To launch the guide, run: `' + this.name + ' server`.\n'))
     console.log(
-      bold('  » Run `git-it` again to launch menu & go onto next challenge\n'))
-    console.log(
-      bold('  » To launch the guide, run: `' + this.name + ' server`.\n'))
-    console.log(
-      bold('  » Or copy this address to your browser:\n' + '  » ' + pathtoguide + ' \n'))
-    if (this.helpFile) {
-      console.log(
-        bold('  » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))
-    }
-    if (this.creditsFile) {
-      console.log(
-        bold('  » For a list of those who contributed to ' + this.name + ', run:\n   `' + this.name + ' credits`.'))
-    }
-    if (this.prerequisitesFile) {
-      console.log(
-        bold('  » For any set up/installion prerequisites for ' + this.name + ', run:\n   `' + this.name + ' prerequisites`.'))
-    }
+      '  » To view guide offline, copy this address to your browser:\n' + '  » ' + pathtoguide + '.html \n'
+      + '  » ' + pathtoguide + '-zhtw.html\n')
+    // if (this.helpFile) {
+    //   console.log(bold("  HELP\n"))
+    //   console.log(
+    //     bold('  » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))
+    // }
+    // if (this.creditsFile) {
+    //   console.log(
+    //     bold('  » For a list of those who contributed to ' + this.name + ', run:\n   `' + this.name + ' credits`.'))
+    // }
+    // if (this.prerequisitesFile) {
+    //   console.log(
+    //     bold('  » For any set up/installion prerequisites for ' + this.name + ', run:\n   `' + this.name + ' prerequisites`.'))
+    // }
     console.log()
   }.bind(this))
 }

--- a/workshopper.js
+++ b/workshopper.js
@@ -63,20 +63,11 @@ Workshopper.prototype.init = function () {
   if (argv.h || argv.help || argv._[0] == 'help')
     return this._printHelp()
 
-<<<<<<< HEAD
   if (argv.s || argv.server || argv._[0] == 'server')
     if (argv._[1]) {
       return this._runServer(argv._[1])
     } else {
       return this._runServer()
-=======
-if (argv.s || argv.server || argv._[0] == 'server')
-  if (argv._[1]) {
-    return this._runServer(argv._[1])
-  } else {
-    return this._runServer()
->>>>>>> tanner-dev
-  }
 
   if (argv._[0] == 'credits')
     return this._printCredits()
@@ -346,25 +337,14 @@ function onpass (setup, dir, current) {
         if (err)
           throw err
 
-<<<<<<< HEAD
-        solutions.forEach(function (file, i) {
-          console.log(repeat('-', this.width) + '\n')
-          if (solutions.length > 1)
-            console.log(bold(file.name) + ':\n')
-          console.log(file.content)
-          if (i == solutions.length - 1)
-            console.log(repeat('-', this.width) + '\n')
-        }.bind(this))
-=======
-        // solutions.forEach(function (file, i) {
-        //   console.log(repeat('-', this.width) + '\n')
-        //   if (solutions.length > 1)
-        //     console.log(bold(file.name) + ':\n')
-        //   console.log(file.content)
-        //   if (i == solutions.length - 1)
-        //     console.log(repeat('-', this.width) + '\n')
-        // }.bind(this))
->>>>>>> tanner-dev
+//        solutions.forEach(function (file, i) {
+//          console.log(repeat('-', this.width) + '\n')
+//          if (solutions.length > 1)
+//            console.log(bold(file.name) + ':\n')
+//          console.log(file.content)
+//          if (i == solutions.length - 1)
+//            console.log(repeat('-', this.width) + '\n')
+//        }.bind(this))
 
         this.updateData('completed', function (xs) {
           if (!xs) xs = []
@@ -428,28 +408,6 @@ function onselect (name) {
     file = txt
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
-<<<<<<< HEAD
-    console.log(
-      bold('\n » To print these instructions again, run: `' + this.name + ' print`.'))
-    console.log(
-      bold(' » To execute your program in a test environment, run:\n   `' + this.name + ' run program.js`.'))
-    console.log(
-      bold(' » To verify your program, run: `' + this.name + ' verify program.js`.'))
-    if (this.helpFile) {
-      console.log(
-        bold(' » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))
-    }
-    if (this.creditsFile) {
-      console.log(
-        bold(' » For a list of those who contributed to ' + this.name + ', run:\n   `' + this.name + ' credits`.'))
-    }
-    if (this.prerequisitesFile) {
-      console.log(
-        bold(' » For any set up/installion prerequisites for ' + this.name + ', run:\n   `' + this.name + ' prerequisites`.'))
-    }
-    console.log()
-=======
-    var pathtoguide = path.join(this.appDir, 'guide', 'index');
     console.log(bold(green(strings.verify)))
     console.log(bold(green(strings.next)))
     console.log(bold(green(strings.guide)))

--- a/workshopper.js
+++ b/workshopper.js
@@ -68,6 +68,7 @@ Workshopper.prototype.init = function () {
       return this._runServer(argv._[1])
     } else {
       return this._runServer()
+    }
 
   if (argv._[0] == 'credits')
     return this._printCredits()

--- a/workshopper.js
+++ b/workshopper.js
@@ -277,11 +277,9 @@ Workshopper.prototype._runServer = function () {
 
   server.on('listening', function () {
     var addr = this.address()
-    console.log(bold('\n Server time! ᕕ( ᐛ )ᕗ') + '\n The server is now running from this window.\n\n'
-      + ' It\'s serving the guide at this address, paste it in your broswer: %s:%s', bold('http://localhost'), bold(addr.port) + '\n'
-      + ' Next, open a new terminal window and run `git-it` again and work from there.\n\n'
-      + ' When you are done you can close this window or press CTRL + C to end the server.\n'
-      + ' BEEP BOOP')
+    console.log('Open this in your browser: %s:%s', 'http://localhost', addr.port + '\n'
+      + 'Open a new terminal window and run `git-it` again.\n'
+      + 'When you are done with server, press CTRL + C to end it.')
   })
 }
 
@@ -409,22 +407,24 @@ function onselect (name) {
     // console.log(
     //   bold(' » To execute your program in a test environment, run:\n   `' + this.name + ' run program.js`.'))
     console.log(
-      bold(' » To launch the guide, run: `' + this.name + ' server`.\n'))
+      bold('  » To verify your work for this problem, run: `' + this.name + ' verify`.\n'))
     console.log(
-      bold(' » Or copy this address to your browser:\n' + ' » ' + pathtoguide + ' \n'))
+      bold('  » Run `git-it` again to launch menu & go onto next challenge\n'))
     console.log(
-      bold(' » To verify your work for this problem, run: `' + this.name + ' verify`.\n'))
+      bold('  » To launch the guide, run: `' + this.name + ' server`.\n'))
+    console.log(
+      bold('  » Or copy this address to your browser:\n' + '  » ' + pathtoguide + ' \n'))
     if (this.helpFile) {
       console.log(
-        bold(' » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))
+        bold('  » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))
     }
     if (this.creditsFile) {
       console.log(
-        bold(' » For a list of those who contributed to ' + this.name + ', run:\n   `' + this.name + ' credits`.'))
+        bold('  » For a list of those who contributed to ' + this.name + ', run:\n   `' + this.name + ' credits`.'))
     }
     if (this.prerequisitesFile) {
       console.log(
-        bold(' » For any set up/installion prerequisites for ' + this.name + ', run:\n   `' + this.name + ' prerequisites`.'))
+        bold('  » For any set up/installion prerequisites for ' + this.name + ', run:\n   `' + this.name + ' prerequisites`.'))
     }
     console.log()
   }.bind(this))

--- a/workshopper.js
+++ b/workshopper.js
@@ -68,7 +68,8 @@ Workshopper.prototype.init = function () {
   if (argv.s || argv.server || argv._[0] == 'server')
     if (argv._[1]) {
       return this._runServer(argv._[1])
-    } else {
+    }
+    else {
       return this._runServer()
     }
 
@@ -92,14 +93,18 @@ Workshopper.prototype.init = function () {
 
   if (argv._[0] == 'select' || argv._[0] == 'print') {
     return onselect.call(this, argv._.length > 1
-      ? argv._.slice(1).join(' ')
-      : this.getData('current')
+        ? argv._.slice(1).join(' ')
+        : this.getData('current')
     )
   }
 
   var run = argv._[0] == 'run'
   if (argv._[0] == 'verify' || run)
     return this.verify(run)
+
+  if (argv._[0] == 'reset') {
+    return this.reset()
+  }
 
   this.printMenu()
 }
@@ -168,6 +173,11 @@ Workshopper.prototype.problems = function () {
   if (!this._problems)
     this._problems = require(path.join(this.appDir, 'menu.json'))
   return this._problems
+}
+
+Workshopper.prototype.reset = function () {
+  fs.unlink(path.resolve(this.dataDir, 'completed.json'), function () {})
+  fs.unlink(path.resolve(this.dataDir, 'current.json'), function () {})
 }
 
 Workshopper.prototype.getData = function (name) {

--- a/workshopper.js
+++ b/workshopper.js
@@ -187,7 +187,7 @@ Workshopper.prototype.runSolution = function (setup, dir, current, run) {
     bold(yellow((run ? 'Running' : 'Verifying') + ' "' + current + '"...')) + '\n'
   )
 
-  var a   = submissionCmd(setup)
+  var a   = submissionCmd(dir, setup)
     , b   = solutionCmd(dir, setup)
     , v   = verify(a, b, {
           a      : setup.a
@@ -229,7 +229,9 @@ function solutionCmd (dir, setup) {
   return exec.concat(args)
 }
 
-function submissionCmd (setup) {
+function submissionCmd (dir, setup) {
+  var filename = argv._[1]
+  if (!filename) filename = dir + '/verify.js'
   var args = setup.args || setup.submissionArgs || []
     , exec
 
@@ -240,14 +242,14 @@ function submissionCmd (setup) {
       , require.resolve('./module-use-tracker')
       , setup.modUseTrack.trackFile
       , setup.modUseTrack.modules.join(',')
-      , argv._[1]
+      , filename
     ]
   } else if (setup.execWrap) {
     exec = [ require.resolve('./exec-wrapper') ]
     exec = exec.concat(setup.execWrap)
-    exec = exec.concat(argv._[1])
+    exec = exec.concat(filename)
   } else {
-    exec = [ argv._[1] ]
+    exec = [ filename ]
   }
 
   return exec.concat(args)

--- a/workshopper.js
+++ b/workshopper.js
@@ -412,11 +412,8 @@ function onselect (name) {
     var pathtoguide = path.join(this.appDir, 'guide', 'index');
     console.log(bold(green(strings.verify)))
     console.log(bold(green(strings.next)))
-//
     console.log(bold(green(strings.guide)))
     console.log(bold(green(strings.offline)))
-//
-//    console.log()
   }.bind(this))
 }
 

--- a/workshopper.js
+++ b/workshopper.js
@@ -24,7 +24,6 @@ const defaultWidth = 65;
 
 function Workshopper (options) {
   config = _.assign(config, options.config)
-  console.log('new config: ', config)
 
   if (!(this instanceof Workshopper))
     return new Workshopper(options)
@@ -411,8 +410,8 @@ function onselect (name) {
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
     var pathtoguide = path.join(this.appDir, 'guide', 'index');
-    console.log(bold(green(config.verify)))
-    console.log(bold(green(config.next)))
+//    console.log(bold(green(config.verify)))
+//    console.log(bold(green(config.next)))
 //
 //    console.log(bold(green(config.guide)))
 //    console.log(config.offline)

--- a/workshopper.js
+++ b/workshopper.js
@@ -381,11 +381,11 @@ function onselect (name) {
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
     console.log(
-      bold('\n » To print these instructions again, run: `' + this.name + ' print`.'))
+      bold('\n » To print these instructions again, run: `' + this.name + ' print`.\n'))
+    // console.log(
+    //   bold(' » To execute your program in a test environment, run:\n   `' + this.name + ' run program.js`.'))
     console.log(
-      bold(' » To execute your program in a test environment, run:\n   `' + this.name + ' run program.js`.'))
-    console.log(
-      bold(' » To verify your program, run: `' + this.name + ' verify program.js`.'))
+      bold(' » To verify your work for this problem, run: `' + this.name + ' verify`.\n'))
     if (this.helpFile) {
       console.log(
         bold(' » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))

--- a/workshopper.js
+++ b/workshopper.js
@@ -405,34 +405,13 @@ function onselect (name) {
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
     var pathtoguide = path.join(this.appDir,'guide', 'index')
-    // console.log(
-    //   bold('\n » To print these instructions again, run: `' + this.name + ' print`.\n'))
-    // console.log(
-    //   bold(' » To execute your program in a test environment, run:\n   `' + this.name + ' run program.js`.'))
-    console.log(
-      bold(green('  » To verify your work for this problem, run: `' + this.name + ' verify`.\n  » Run `git-it` again to launch menu & go onto next challenge\n')))
-    // console.log(
-    //   bold(green('  » Run `git-it` again to launch menu & go onto next challenge\n')))
-    console.log(bold(green('  GUIDE\n')))
-    console.log(green('  » Open the guide in your browser: jlord.github.io/git-it\n' + '  » Traditional Chinese guide: jlord.github.io/git-it/index-zhtw.html\n'))
-    // console.log(
-    //   bold('  » To launch the guide, run: `' + this.name + ' server`.\n'))
-    console.log(
-      '  » To view guide offline, copy this address to your browser:\n' + '  » ' + pathtoguide + '.html \n'
-      + '  » ' + pathtoguide + '-zhtw.html\n')
-    // if (this.helpFile) {
-    //   console.log(bold("  HELP\n"))
-    //   console.log(
-    //     bold('  » For help with this problem or with ' + this.name + ', run:\n   `' + this.name + ' help`.'))
-    // }
-    // if (this.creditsFile) {
-    //   console.log(
-    //     bold('  » For a list of those who contributed to ' + this.name + ', run:\n   `' + this.name + ' credits`.'))
-    // }
-    // if (this.prerequisitesFile) {
-    //   console.log(
-    //     bold('  » For any set up/installion prerequisites for ' + this.name + ', run:\n   `' + this.name + ' prerequisites`.'))
-    // }
+
+    console.log(bold(green(workshopStrings.verify)))
+    console.log(bold(green(workshopStrings.next)))
+
+    console.log(bold(green(workshopStrings.guide)))
+    console.log(workshopStrings.offline)
+
     console.log()
   }.bind(this))
 }

--- a/workshopper.js
+++ b/workshopper.js
@@ -278,12 +278,12 @@ Workshopper.prototype._printUsage = function () {
 
 function onpass (setup, dir, current) {
   console.log(bold(green('# PASS')))
-  console.log('\nYour solution to ' + current + ' passed!')
+  console.log(green(bold('\nYour solution to ' + current + ' passed!')))
 
   if (setup.hideSolutions)
     return
 
-  console.log('\nHere\'s what the official solution is if you want to compare notes:\n')
+  // console.log('\nHere\'s what the official solution is if you want to compare notes:\n')
 
   var solutions = fs.readdirSync(dir).filter(function (file) {
         return (/^solution.*\.js/).test(file)
@@ -309,14 +309,14 @@ function onpass (setup, dir, current) {
         if (err)
           throw err
 
-        solutions.forEach(function (file, i) {
-          console.log(repeat('-', this.width) + '\n')
-          if (solutions.length > 1)
-            console.log(bold(file.name) + ':\n')
-          console.log(file.content)
-          if (i == solutions.length - 1)
-            console.log(repeat('-', this.width) + '\n')
-        }.bind(this))
+        // solutions.forEach(function (file, i) {
+        //   console.log(repeat('-', this.width) + '\n')
+        //   if (solutions.length > 1)
+        //     console.log(bold(file.name) + ':\n')
+        //   console.log(file.content)
+        //   if (i == solutions.length - 1)
+        //     console.log(repeat('-', this.width) + '\n')
+        // }.bind(this))
         
         this.updateData('completed', function (xs) {
           if (!xs) xs = []
@@ -330,6 +330,7 @@ function onpass (setup, dir, current) {
         if (remaining === 0) {
           console.log('You\'ve finished all the challenges! Hooray!\n')
         } else {
+          console.log(repeat('-', this.width) + '\n')
           console.log(
               'You have '
             + remaining
@@ -338,6 +339,7 @@ function onpass (setup, dir, current) {
             + ' left.'
           )
           console.log('Type `' + this.name + '` to show the menu.\n')
+          console.log(repeat('-', this.width) + '\n')
         }
         
         if (setup.close)

--- a/workshopper.js
+++ b/workshopper.js
@@ -6,6 +6,7 @@ const argv       = require('optimist').argv
     , msee       = require('msee')
     , http       = require('http')
     , ecstatic   = require('ecstatic')
+    , _          = require('lodash')
 
 const showMenu  = require('./menu')
     , verify    = require('./verify')
@@ -17,9 +18,14 @@ const showMenu  = require('./menu')
     , yellow    = require('./term-util').yellow
     , center    = require('./term-util').center
 
-const defaultWidth = 65
+var config = require('./config');
+
+const defaultWidth = 65;
 
 function Workshopper (options) {
+  config = _.assign(config, options.config)
+  console.log('new config: ', config)
+
   if (!(this instanceof Workshopper))
     return new Workshopper(options)
 
@@ -404,15 +410,14 @@ function onselect (name) {
     file = txt
 
   printText(this.name, this.appDir, file, path.extname(file), function () {
-    var pathtoguide = path.join(this.appDir,'guide', 'index')
-
-    console.log(bold(green(workshopStrings.verify)))
-    console.log(bold(green(workshopStrings.next)))
-
-    console.log(bold(green(workshopStrings.guide)))
-    console.log(workshopStrings.offline)
-
-    console.log()
+    var pathtoguide = path.join(this.appDir, 'guide', 'index');
+    console.log(bold(green(config.verify)))
+    console.log(bold(green(config.next)))
+//
+//    console.log(bold(green(config.guide)))
+//    console.log(config.offline)
+//
+//    console.log()
   }.bind(this))
 }
 

--- a/workshopper.js
+++ b/workshopper.js
@@ -386,6 +386,24 @@ function onfail (setup, dir, current) {
   else
     console.log('\nYour solution to ' + current + ' didn\'t match the expected output.\nTry again!')
     console.log(repeat('-', this.width) + '\n')
+
+  // trying to show our example
+
+    var example = fs.readdirSync(dir).filter(function (file) {
+      return (/^example.*\.html/).test(file)
+    })
+
+//      .map(function (file) {
+//      return fs.readFileSync(path.join(dir, file), 'utf8')
+//         // .toString()
+//        //  .replace(/^/gm, '  ')
+//      }
+//    )
+
+    console.log('Here\'s what our solution looks like:')
+    console.log(example)
+    console.log(repeat('-', this.width) + '\n')
+
 }
 
 function onselect (name) {

--- a/workshopper.js
+++ b/workshopper.js
@@ -367,6 +367,18 @@ function onpass (setup, dir, current) {
 
         remaining = this.problems().length - completed.length
         if (remaining === 0) {
+          console.log(repeat('-', this.width))
+          console.log('Here\'s what our solution looks like:' + '\n')
+
+          var example = fs.readdirSync(dir).filter(function (file) {
+            return (/^example.*\.html/).test(file)
+          }).map(function (file) {
+              shell.echo(fs.readFileSync(path.join(dir, file), 'utf8'))
+              //    .toString()
+              //     .replace(/^/gm, '  ')
+            }
+          )
+          console.log(repeat('-', this.width))
           console.log('You\'ve finished all the challenges! Hooray!\n')
         } else {
           // trying to show our example


### PR DESCRIPTION
allows future workshop creators to use this workshopper framework without printing lines that refer users to the git-it guides. allows those workshop creators to update the strings that are pushed to the console on lesson select/pass with names and links relative to their workshop.

this is accomplished easily by updating a strings.json file.

updated documentation to reflect these changes
